### PR TITLE
rg: fix cairo.h inclusion

### DIFF
--- a/contrib/rg/rg-renderer.c
+++ b/contrib/rg/rg-renderer.c
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <cairo/cairo.h>
+#include <cairo.h>
 
 #include "rg-renderer.h"
 


### PR DESCRIPTION
It seems that common practice is to include `<cairo.h>`, not `<cairo/cairo.h>`. This is how it works in **pango** and **vala**. This commit fixes https://github.com/chergert/gnome-builder/issues/53.