### PR TITLE
Support non-Adwaita themes

### DIFF
--- a/data/theme/fallback-dark.css
+++ b/data/theme/fallback-dark.css
@@ -4,7 +4,7 @@
 eggsearchbar box.search-bar {
   background-color: @darker_theme_bg_color;
   box-shadow: 0 4px 3px -5px @box_shadow_color inset,
-              0 -1px 0 @light_borders inset;
+              0 -1px 0 @light_borders /*#a1a1a1*/ inset;
 }
 eggsearchbar:backdrop box.search-bar {
   background-color: red; /*#d5d5d5;*/
@@ -16,18 +16,18 @@ perspectiveswitcher {
   background: shade(@theme_bg_color, 1.1); /*#f4f4f4;*/
 }
 perspectiveswitcher button {
-  color: shade(@theme_text_color, 2.2); /*#bebebe;*/
+  color: shade(@theme_text_color, 0.5); /*#bebebe;*/
 }
 perspectiveswitcher button:checked,
 perspectiveswitcher button:checked:hover {
   color: @theme_text_color; /*#2e3436;*/
 }
 perspectiveswitcher button:hover {
-  color: shade(@theme_text_color, 1.3); /*mix(#bebebe, #2e3436, 0.3);*/
+  color: shade(@theme_text_color, 0.9); /*mix(#bebebe, #2e3436, 0.3);*/
 }
 
 pillbox {
-  background-color: shade(theme_bg_color, 1.2);
+  background-color: @darker_theme_bg_color;
   color: @theme_text_color;
   border-radius: 3px;
 }
@@ -42,7 +42,7 @@ layouttab {
   box-shadow: 0 4px 3px -5px @box_shadow_color inset;
 }
 layouttab:backdrop {
-  background-color: shade(@theme_selected_bg_color, 0.9);
+  background-color: shade(@theme_bg_color, 0.9);
   border-right-color: alpha(@borders, 0.5);
   border-left-color: alpha(@borders, 0.5);
 }

--- a/data/theme/fallback-panels.css
+++ b/data/theme/fallback-panels.css
@@ -1,0 +1,50 @@
+dockbin {
+  border: 1px solid alpha(@borders, 0.75);
+  -PnlDockBin-handle-size: 1;
+}
+
+dockpaned {
+  border: 1px solid @borders;
+}
+
+docktabstrip {
+  padding: 0 6px 0 6px;
+}
+
+docktab {
+  background-image: none;
+  background-color: transparent;
+  border-color: transparent;
+  border-style: solid;
+  color: @theme_fg_color;
+  min-height: 39px;
+  outline-offset: -6px;
+  transition-duration: 200ms;
+  transition-timing-function: ease;
+}
+
+docktab > label {
+  font-size: 0.9em;
+}
+
+docktab > * {
+  padding: 0 6px 0 6px;
+}
+
+dockoverlayedge {
+  background-color: @theme_bg_color;
+}
+
+dockoverlayedge docktabstrip {
+  padding: 0;
+  border: none;
+}
+
+dockoverlayedge.left-edge docktab:checked {
+  border-right-color: @theme_selected_bg_color;
+  border-bottom-color: transparent;
+}
+dockoverlayedge.right-edge docktab:checked {
+  border-left-color: @theme_selected_bg_color;
+  border-bottom-color: transparent;
+}

--- a/data/theme/fallback-shared.css
+++ b/data/theme/fallback-shared.css
@@ -1,0 +1,133 @@
+@import url("resource:///org/gnome/builder/theme/shared.css");
+@import url("resource:///org/gnome/builder/theme/fallback-panels.css");
+
+
+/*
+ * Titlebar adjustments for workbench
+ *
+ * This is needed due to our placement of headerbar inside of a
+ * stack. We were seeing black edges around the header bar, and
+ * improper radius on the headerbar.
+ */
+workbench stack.titlebar {
+  border-bottom: none;
+  border-radius: 6px 6px 0 0;
+  box-shadow: none;
+  padding: 0;
+}
+workbench stack.titlebar headerbar {
+  border-radius: 6px 6px 0 0;
+  margin: 0;
+  border-bottom: none;
+  box-shadow: 0 -1px 0 @borders inset;
+}
+workbench stack.titlebar headerbar:backdrop {
+  box-shadow: 0 -1px 0 alpha(@borders, 0.6) inset;
+}
+
+
+/*
+ * Layout tab and tab bar tweaks
+ *
+ * The following makes the layout stack header look similar to a tab bar.
+ */
+layouttabbar > box > button {
+  opacity: 0.5;
+}
+layouttabbar > box > button:hover {
+  opacity: 0.75;
+}
+layouttabbar > box > button:active {
+  opacity: 1;
+}
+layouttabbar button {
+  border: none;
+  box-shadow: none;
+  background: transparent;
+}
+layouttab label {
+  padding: 5px;
+}
+layouttab {
+  background-color: @theme_bg_color;
+
+  border-bottom: 3px;
+  border-bottom-style: solid;
+
+  border-right: 1px solid alpha(@borders, 0.75);
+  border-left: 1px solid alpha(@borders, 0.75);
+
+  border-bottom-left-radius: 3px;
+  border-bottom-right-radius: 3px;
+}
+layouttab:backdrop {
+  border-right-color: alpha(@borders, 0.75);
+  border-left-color: alpha(@borders, 0.75);
+  box-shadow: none;
+}
+layouttabbar:backdrop {
+  box-shadow: none;
+}
+layouttab separator.vertical {
+  margin-top: 7px;
+  margin-bottom: 7px;
+  opacity: 0.75;
+}
+layouttab separator.vertical:backdrop {
+  opacity: 0.3;
+}
+layouttab button:disabled,
+layouttab button {
+  background: none;
+  border: none;
+  box-shadow: none;
+  padding-left: 4px;
+  padding-right: 4px;
+}
+
+
+/*
+ * Close button styling for layouttab.
+ */
+layouttab > box > button:last-child image {
+  color: @theme_fg_color;
+  opacity: 0.3;
+  margin: 2px;
+  border: 1px solid transparent;
+  border-radius: 3px;
+}
+layouttab > box > button:last-child:hover image {
+  opacity: .75;
+  transition-duration: 250ms;
+  border: 1px solid @borders;
+}
+layouttab > box > button:last-child:active image {
+  opacity: .8;
+  background-image: linear-gradient(shade(@theme_bg_color, 0.9), @theme_bg_color);
+}
+layouttab > box > button:last-child:backdrop image {
+  opacity: .1;
+}
+
+
+layout {
+  border: 1px solid alpha(@borders, 0.75);
+  -PnlDockBin-handle-size: 1;
+}
+
+
+entry.search-missing {
+  background-image: none;
+  background-color: @error_color;
+  color: @theme_selected_fg_color;
+  text-shadow: none;
+}
+
+entry.search-missing > * {
+  background-color: @error_color;
+  color: @theme_selected_fg_color;
+}
+
+/* tweak icons for treeviews */
+treeview.image { color: alpha(currentColor, 0.8); }
+treeview.image:selected { color: alpha(@theme_selected_fg_color, 0.9); }

--- a/data/theme/fallback.css
+++ b/data/theme/fallback.css
@@ -1,0 +1,68 @@
+@import url("resource:///org/gnome/builder/theme/fallback-shared.css");
+
+
+eggsearchbar box.search-bar {
+  background-color: @darker_theme_bg_color;
+  box-shadow: 0 4px 3px -5px @box_shadow_color inset,
+              0 -1px 0 @light_borders /*#a1a1a1*/ inset;
+}
+eggsearchbar:backdrop box.search-bar {
+  background-color: red; /*#d5d5d5;*/
+  box-shadow: none;
+}
+
+
+perspectiveswitcher {
+  background: shade(@theme_bg_color, 1.1); /*#f4f4f4;*/
+}
+perspectiveswitcher button {
+  color: shade(@theme_text_color, 2.2); /*#bebebe;*/
+}
+perspectiveswitcher button:checked,
+perspectiveswitcher button:checked:hover {
+  color: @theme_text_color; /*#2e3436;*/
+}
+perspectiveswitcher button:hover {
+  color: shade(@theme_text_color, 1.3); /*mix(#bebebe, #2e3436, 0.3);*/
+}
+
+pillbox {
+  background-color: @darker_theme_bg_color;
+  color: @theme_text_color;
+  border-radius: 3px;
+}
+
+layouttabbar {
+  background-color: @darker_theme_bg_color;
+  border-bottom: 1px solid @light_borders;
+  box-shadow: 0 4px 3px -5px @box_shadow_color inset;
+}
+layouttab {
+  border-bottom-color: @theme_selected_bg_color;
+  box-shadow: 0 4px 3px -5px @box_shadow_color inset;
+}
+layouttab:backdrop {
+  background-color: red; /*#efefef;*/
+  border-right-color: alpha(@borders, 0.5);
+  border-left-color: alpha(@borders, 0.5);
+}
+
+docktabstrip {
+  background-color: shade(@theme_bg_color, 0.9);
+  box-shadow: 0 4px 3px -5px @box_shadow_color inset,
+              0 -1px 0 @light_borders inset;
+}
+docktabstrip:backdrop {
+  box-shadow: 0 -1px 0 @light_borders inset;
+}
+docktabstrip docktab:checked {
+  box-shadow: 0 -2px 0 @theme_selected_bg_color inset;
+}
+
+entry.search-missing {
+  border-color: shade(@error_color, 0.8);
+}
+
+@define-color box_shadow_color @theme_bg_color; /* #aaa in Adwaita gnome-builder theme*/
+@define-color darker_theme_bg_color shade(@theme_bg_color, 0.9); /* #d6d6d6 */
+@define-color light_borders shade(@borders, 1.1); /* #a1a1a1 */

--- a/libide/ide-css-provider.c
+++ b/libide/ide-css-provider.c
@@ -88,7 +88,7 @@ ide_css_provider_update (IdeCssProvider *self)
   if (!g_resources_get_info (resource_path, G_RESOURCE_LOOKUP_FLAGS_NONE, &len, &flags, NULL))
     {
       g_free (resource_path);
-      resource_path = g_strdup_printf ("%s/theme/shared.css", self->base_path);
+      resource_path = g_strdup_printf ("%s/theme/fallback.css", self->base_path);
     }
 
   /* Nothing to load */

--- a/libide/ide-css-provider.c
+++ b/libide/ide-css-provider.c
@@ -88,8 +88,12 @@ ide_css_provider_update (IdeCssProvider *self)
   if (!g_resources_get_info (resource_path, G_RESOURCE_LOOKUP_FLAGS_NONE, &len, &flags, NULL))
     {
       g_free (resource_path);
-      resource_path = g_strdup_printf ("%s/theme/fallback.css", self->base_path);
+      resource_path = g_strdup_printf ("%s/theme/fallback%s.css", 
+                                       self->base_path, 
+                                       prefer_dark_theme ? "-dark" : "");
     }
+
+  IDE_TRACE_MSG ("Loading css overrides \"%s\"", resource_path);
 
   /* Nothing to load */
   if (!g_resources_get_info (resource_path, G_RESOURCE_LOOKUP_FLAGS_NONE, &len, &flags, NULL))

--- a/libide/resources/libide.gresource.xml
+++ b/libide/resources/libide.gresource.xml
@@ -32,6 +32,7 @@
     <file compressed="true" alias="Arc-shared.css">../../data/theme/Arc-shared.css</file>
 
     <file compressed="true" alias="fallback.css">../../data/theme/fallback.css</file>
+    <file compressed="true" alias="fallback-dark.css">../../data/theme/fallback-dark.css</file>
     <file compressed="true" alias="fallback-panels.css">../../data/theme/fallback-panels.css</file>
     <file compressed="true" alias="fallback-shared.css">../../data/theme/fallback-shared.css</file>
 

--- a/libide/resources/libide.gresource.xml
+++ b/libide/resources/libide.gresource.xml
@@ -31,6 +31,10 @@
     <file compressed="true" alias="Arc-Darker-dark.css">../../data/theme/Arc-Dark.css</file>
     <file compressed="true" alias="Arc-shared.css">../../data/theme/Arc-shared.css</file>
 
+    <file compressed="true" alias="fallback.css">../../data/theme/fallback.css</file>
+    <file compressed="true" alias="fallback-panels.css">../../data/theme/fallback-panels.css</file>
+    <file compressed="true" alias="fallback-shared.css">../../data/theme/fallback-shared.css</file>
+
     <file compressed="true" alias="shared.css">../../data/theme/shared.css</file>
   </gresource>
 


### PR DESCRIPTION
This adds support for non-Adwaita themes by adapting the existing Adwaita CSS into a set of fallback CSS files that rely on theme colors instead of custom colors. 

This is linked to bug report:

https://bugzilla.gnome.org/show_bug.cgi?id=767767