### PR TITLE
readme: change irc server from gimp.net to gnome.org

### DIFF
--- a/README
+++ b/README
@@ -5,7 +5,7 @@ Builder - Develop software for GNOME
  Download: https://download.gnome.org/sources/gnome-builder/
       Git: http://git.gnome.org/browse/gnome-builder
   Website: https://wiki.gnome.org/Apps/Builder
-      IRC: irc.gimp.net #gnome-builder
+      IRC: irc.gnome.org #gnome-builder
 
 ----
 


### PR DESCRIPTION
I wanted to ask a question on IRC and failed to connect to `irc.gimp.net`.